### PR TITLE
Fix two bugs in name matching and + replacement of query string

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -54,7 +54,7 @@ function init(data){
   var q = decodeURI(location.search.substring(3)); // format: ?q=  - this is stripped out
   if(q != ""){
     q=q.toTitleCase();
-    q=q.replace('+', '%20');
+    q=q.replace(/+/g, '%20');
     $('.typeahead').typeahead('val', q);
     createCard(getInfo(q));
   }
@@ -554,7 +554,7 @@ function getInfo(sug){
 
   for(var type in compendium){
     for(var data in compendium[type]){
-      if(compendium[type][data].name == sug){
+      if(compendium[type][data].name.localeCompare(sug, undefined, { sensitivity: 'base' }) === 0) {
         compendium[type][data].type = type;
         return compendium[type][data];
       }


### PR DESCRIPTION
I ran into these issues linking directly to [Frostbite (EE)](https://radai.github.io/dnd5tools/?q=Frostbite%20(EE)). This card loads if you open the site without a query parameter, but does not when directly linked.

[String.localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) is a dependable way to check if strings are equal as `{sensitivity: 'base'}` allows it to ignore case and accent marks.

Awesome tool BTW! It has vastly improved my D&D experience! Thanks.