### PR TITLE
Fix regex syntax issue with replacing '+' characters

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -54,7 +54,7 @@ function init(data){
   var q = decodeURI(location.search.substring(3)); // format: ?q=  - this is stripped out
   if(q != ""){
     q=q.toTitleCase();
-    q=q.replace(/+/g, '%20');
+    q=q.replace(/\+/g, '%20');
     $('.typeahead').typeahead('val', q);
     createCard(getInfo(q));
   }


### PR DESCRIPTION
Ah, sorry I didn't setup a local webserver to test the prior change and introduced a bug. I've tested this fix locally, though, and it looks to be fixed.